### PR TITLE
s3에서 이미지 조회하는 코드 제거

### DIFF
--- a/src/main/java/com/couponmoa/backend/couponmoauser/domain/user/service/v1/UserServiceV1.java
+++ b/src/main/java/com/couponmoa/backend/couponmoauser/domain/user/service/v1/UserServiceV1.java
@@ -25,7 +25,7 @@ public class UserServiceV1 {
     @Transactional(readOnly = true)
     public UserResponse findUser(Long userId) {
         User user = getUserById(userId);
-        return UserResponse.fromEntityV1(user);
+        return UserResponse.fromEntityV2(user);
     }
 
     @Transactional


### PR DESCRIPTION
📌 반영 브랜치
feat/user -> dev

🚨 연관 이슈
Resolve: https://github.com/sparta-final-organization/couponmoa-user/issues/1

✅ 작업 내용 (Tasks)

기존에 s3와 cloudfront의 이미지 조회를 v1, v2로 나누어 성능 비교를 했는데, 성능 차이 확인 되었으니 s3에서 직접 이미지 조회하는 정책을 보안상 없애고 cloudfront에서만 이미지를 조회할 수 있도록 코드 한 부분 수정했습니다

🎯 테스트 결과
이미지 정상 조회(테스트 안해봄)